### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ BUILD_DIR = build
 # C sources
 C_SOURCES =  \
 Src/analog.c \
+Src/axis_to_buttons.c \
 Src/buttons.c \
 Src/crc16.c \
 Src/encoders.c \


### PR DESCRIPTION
The Makefile is broken since the last merge, resulting in the following message:
```
in function `ButtonsCheck':
FreeJoy/Src/buttons.c:409: undefined reference to `AxesToButtonsProcess'
collect2: error: ld returned 1 exit status
make: *** [Makefile:188: build/FreeJoy.elf] Error 1
```
Adding the one line seems to fix it.  
But since the Makefile is autogenerated you may prefer to regenerate it.  
I didn't figure out how to do that so I edited it by hand.  

Thanks for sharing your work!  
I'm currently building my own joystick and it looks like FreeJoy has everything i need (and more).  
Really looking forward to using it :)  