### PR TITLE
Make `button_mutex` volatile

### DIFF
--- a/application/Src/buttons.c
+++ b/application/Src/buttons.c
@@ -36,7 +36,7 @@ uint8_t												pov_pos[MAX_POVS_NUM];
 uint8_t												shifts_state = 0;
 uint8_t												a2b_first = 0;
 uint8_t												a2b_last = 0;
-uint8_t												button_mutex = 0;
+volatile uint8_t							button_mutex = 0;
 
 /**
   * @brief  Processing debounce for raw buttons input


### PR DESCRIPTION
### Issue

When reading the button data in `ButtonsGet()`, it appears at first glance that the data is protected by `button_mutex`:
https://github.com/FreeJoy-Team/FreeJoy/blob/8f144268c6065fa51e961f3d26034db604a606e9/application/Src/buttons.c#L1022-L1024

However, `button_mutex` is not marked as volatile:
https://github.com/FreeJoy-Team/FreeJoy/blob/8f144268c6065fa51e961f3d26034db604a606e9/application/Src/buttons.c#L39

In `ButtonsReadLogical()`, the value is written here:
https://github.com/FreeJoy-Team/FreeJoy/blob/8f144268c6065fa51e961f3d26034db604a606e9/application/Src/buttons.c#L940-L941
And then subsequently written again in the same function:
https://github.com/FreeJoy-Team/FreeJoy/blob/8f144268c6065fa51e961f3d26034db604a606e9/application/Src/buttons.c#L977-L978

When optimizations are enabled, the compiler:
- Sees two writes to the same variable
- Concludes that the only required side-effect is that `button_mutex` must be `0` when returning from the function
    - (since `button_mutex` is not marked as `volatile`)
- Never writes `1` to `button_mutex`

This in turn means that, in `ButtonsGet()`, isn't actually protected by the mutex in the expected manner (since it always has the value `0`), and can therefore sometimes return all zeros for the button states, due to the button states being cleared here:
https://github.com/FreeJoy-Team/FreeJoy/blob/8f144268c6065fa51e961f3d26034db604a606e9/application/Src/buttons.c#L943

### Solution

Mark `button_mutex` as `volatile`

### Discussion

I found this bug because my engine kept cutting out in the game I was playing -- a toggle switch was sometimes sending a value of `0`, which caused the engine to be turned off.  I then sniffed the USB data with Wireshark, and noticed that occasionally all buttons were set to `0`.  After that, I noticed that a variable was shared between the "main" and "interrupt" contexts, without being marked as volatile, which led me to investigate further.

This behaviour can also be seen as flickering in the freejoy configurator.

Since marking the variable as `volatile`, and flashing the new code, the problem has gone away.