### PR TITLE
Fix USB OUT delay for LED reports (prevent joystick reporting pauses)

### DIFF
--- a/application/Inc/common_defines.h
+++ b/application/Inc/common_defines.h
@@ -11,7 +11,7 @@
 
 //#define DEBUG
 
-#define FIRMWARE_VERSION					0x1730			// v1.7.3b0
+#define FIRMWARE_VERSION					0x1731			// v1.7.3b1
 #define USED_PINS_NUM							30					// constant for BluePill and BlackPill boards
 #define MAX_AXIS_NUM							8						// max 8
 #define MAX_BUTTONS_NUM						128					// power of 2, max 128

--- a/application/Inc/main.h
+++ b/application/Inc/main.h
@@ -18,7 +18,7 @@
 
 static const dev_config_t init_config =
 {
-	.firmware_version = 0x1730,		// do not change
+	.firmware_version = 0x1731,		// do not change
 	/* 
 		Name of device in devices dispatcher
 	*/

--- a/application/Src/usb_endp.c
+++ b/application/Src/usb_endp.c
@@ -115,9 +115,9 @@ void EP2_OUT_Callback(void)
 		SetEPRxStatus(ENDP2, EP_RX_VALID);
 		return;
 	}
-	else 
+	else if (repotId == REPORT_ID_CONFIG_IN || repotId == REPORT_ID_CONFIG_OUT || repotId == REPORT_ID_FIRMWARE)
 	{
-		// 2 second delay for joy report
+		// 2 second delay for joy report during configurator/firmware operations
 		uint64_t delay = GetMillis() + 2000;
 		joy_millis = delay;
 		adc_ticks = buttons_ticks = sensors_ticks = encoder_ticks = delay * TICKS_IN_MILLISECOND;


### PR DESCRIPTION
Fix USB OUT handler delay that caused periodic 2‑second pauses in joystick reporting when non‑REPORT_ID_PARAM packets arrived (including LED HID traffic).

**Root Cause**: The USB OUT handler treated any non‑REPORT_ID_PARAM packet as a configurator/firmware packet and inserted a 2‑second pause, so periodic REPORT_ID_LED traffic triggered repeated joystick “hangs.”

**Fix**: Limit the delay to only configurator/firmware report IDs and leave LED report handling unaffected, preventing joystick reporting stalls during LED HID traffic.

Version: 1.7.3b1