### PR TITLE
Fix encoder ghost HID output on partial rotation

### DIFF
--- a/application/Inc/common_types.h
+++ b/application/Inc/common_types.h
@@ -296,12 +296,13 @@ typedef struct
 {
   int32_t 				time_last;
 	int32_t 				cnt;
-	uint8_t 				state;					//:4?	
+	uint8_t 				state;
 	int8_t 					pin_a;
 	int8_t 					pin_b;
-	int8_t					dir :4;					//:2?
-	int8_t					last_dir :4;		//:2?
-	
+	int8_t					dir :4;
+	int8_t					last_dir :4;
+	uint8_t					cycle_started;		// rastreia se o ciclo iniciou corretamente
+	uint8_t					fsm_state;				// estado da maquina de quadratura
 	
 } encoder_state_t;
 
@@ -310,7 +311,7 @@ typedef struct
 typedef struct
 {
 	uint8_t points[13];
-	uint8_t buttons_cnt;									// :4
+	uint8_t buttons_cnt;
 
 } axis_to_buttons_t;
 
@@ -424,10 +425,10 @@ typedef struct
 	
 	// config 6-7-8-9-10-11-12
 	button_t 						buttons[MAX_BUTTONS_NUM];
-	uint16_t						button_timer1_ms;						// config packet 6				
-	uint16_t						button_timer2_ms;						// config packet 7
-	uint16_t						button_timer3_ms;						// config packet 8
-	uint16_t 						a2b_debounce_ms;						// config packet 9
+	uint16_t						button_timer1_ms;
+	uint16_t						button_timer2_ms;
+	uint16_t						button_timer3_ms;
+	uint16_t 						a2b_debounce_ms;
 	
 	// config 12-13-14
 	axis_to_buttons_t		axes_to_buttons[MAX_AXIS_NUM];
@@ -478,7 +479,7 @@ typedef struct
 /******************** EXTERNAL LED DATA **********************/
 typedef struct
 {
-	uint32_t 						leds_state;		// 24 bits used
+	uint32_t 						leds_state;
 } external_led_data_t;
 
 
@@ -512,8 +513,6 @@ typedef struct
 	analog_data_t			 	axis_data[MAX_AXIS_NUM];
 	uint8_t							buttons_data[MAX_BUTTONS_NUM/8];
 	uint16_t						crc;
-	// uint8_t             endl;
-	// when adding variable after crc don't forget to calc size
 	
 } uart_report_t;
 #pragma pack(pop)

--- a/application/Src/encoders.c
+++ b/application/Src/encoders.c
@@ -24,7 +24,9 @@
 
 #include "encoders.h"
 
-
+/* ---------------------------------------------------------------------------
+ * Tabelas de quadratura originais — mantidas para modo 4x (ALPS RKJXT1F42001)
+ * --------------------------------------------------------------------------- */
 const int8_t enc_array_1 [16] =
 {
 	0,  0,  0,  0,
@@ -49,6 +51,42 @@ const int8_t enc_array_4 [16] =
 	0, -1,  1,  0
 };
 
+/* ---------------------------------------------------------------------------
+ * Maquina de estados em quadratura (FSM) — usada para ENCODER_CONF_1x e 2x
+ *
+ * Encoder configurado como button GND: repouso = AB=11 (ambos HIGH)
+ * Sequencia CW:  11 -> 01 -> 00 -> 10 -> 11  => pulso ao chegar em 11
+ * Sequencia CCW: 11 -> 10 -> 00 -> 01 -> 11  => pulso ao chegar em 11
+ *
+ * Bounce (11->01->11 ou 11->10->11) descartado automaticamente.
+ * Mudanca de direcao imediata detectada sem perder o primeiro step.
+ *
+ * ENCODER_CONF_4x usa enc_array_4 original — necessario para encoders como
+ * o ALPS RKJXT1F42001 que tem detent no meio do ciclo (AB=00), gerando
+ * pulso a cada meia-rotacao de quadratura.
+ * --------------------------------------------------------------------------- */
+#define FSM_R_START     0x00
+#define FSM_DIR_CW      0x10
+#define FSM_DIR_CCW     0x20
+#define FSM_START_M     0x01  /* estado intermediario (00) */
+#define FSM_CW_BEGIN    0x02  /* veio de 11, foi para 01 */
+#define FSM_CCW_BEGIN   0x03  /* veio de 11, foi para 10 */
+#define FSM_CW_BEGIN_M  0x04  /* veio de 00, foi para 10 -> pulso CW */
+#define FSM_CCW_BEGIN_M 0x05  /* veio de 00, foi para 01 -> pulso CCW */
+
+/* Tabela [estado & 0x0F][AB] -> proximo estado
+ * AB: bit1=B, bit0=A. Colunas: 00=0, 01=1, 10=2, 11=3 */
+static const uint8_t fsm_quadrature[6][4] =
+{
+	/*  00               01                10                11                       */
+	{FSM_START_M,    FSM_CW_BEGIN,    FSM_CCW_BEGIN,    FSM_R_START             },  /* R_START       */
+	{FSM_START_M,    FSM_CCW_BEGIN_M, FSM_CW_BEGIN_M,   FSM_R_START             },  /* START_M  (00) */
+	{FSM_START_M,    FSM_CW_BEGIN,    FSM_R_START,      FSM_R_START             },  /* CW_BEGIN (01) */
+	{FSM_START_M,    FSM_R_START,     FSM_CCW_BEGIN,    FSM_R_START             },  /* CCW_BEGIN(10) */
+	{FSM_START_M,    FSM_R_START,     FSM_CW_BEGIN_M,   FSM_R_START|FSM_DIR_CW  },  /* CW_BEGIN_M    */
+	{FSM_START_M,    FSM_CCW_BEGIN_M, FSM_R_START,      FSM_R_START|FSM_DIR_CCW },  /* CCW_BEGIN_M   */
+};
+
 encoder_state_t encoders_state[MAX_ENCODERS_NUM];
 
 static void EncoderFastInit(dev_config_t * p_dev_config)
@@ -58,7 +96,6 @@ static void EncoderFastInit(dev_config_t * p_dev_config)
 	
 	RCC_GetClocksFreq(&RCC_Clocks);
 	
-	// Encoder timer
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM1, ENABLE);		
 	TIM_TimeBaseInitStructure.TIM_Prescaler = 0;
 	TIM_TimeBaseInitStructure.TIM_Period = 65535;
@@ -82,17 +119,79 @@ static void EncoderFastInit(dev_config_t * p_dev_config)
 	TIM_Cmd(TIM1, ENABLE);
 }
 
+static void EmitEncoderPulse(int i, int8_t stt,
+	logical_buttons_state_t * button_state_buf,
+	dev_config_t * p_dev_config,
+	int8_t * ignore_a, int8_t * ignore_b,
+	int32_t millis)
+{
+	if (stt > 0)
+	{
+		if ((p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator > 0 && 
+				shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator-1)))
+		{
+			button_state_buf[encoders_state[i].pin_a].current_state = 1;
+		}
+		else if (p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator == 0)
+		{
+			uint8_t tmp_ignore = 0;
+			for (int k = 0; k < MAX_ENCODERS_NUM; k++)
+			{
+				if (p_dev_config->buttons[encoders_state[i].pin_a].physical_num == ignore_a[k])
+				{
+					tmp_ignore = 1;
+					break;
+				}
+			}
+			if (tmp_ignore == 0)
+			{
+				button_state_buf[encoders_state[i].pin_a].current_state = 1;
+			}
+		}
+	}
+	else
+	{
+		if ((p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator > 0 && 
+				shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator-1)))
+		{
+			button_state_buf[encoders_state[i].pin_b].current_state = 1;
+		}
+		else if (p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator == 0)
+		{
+			uint8_t tmp_ignore = 0;
+			for (int k = 0; k < MAX_ENCODERS_NUM; k++)
+			{
+				if (p_dev_config->buttons[encoders_state[i].pin_b].physical_num == ignore_b[k])
+				{
+					tmp_ignore = 1;
+					break;
+				}
+			}
+			if (tmp_ignore == 0)
+			{
+				button_state_buf[encoders_state[i].pin_b].current_state = 1;
+			}
+		}
+	}
+
+	encoders_state[i].dir       = stt > 0 ? 1 : -1;
+	encoders_state[i].last_dir  = encoders_state[i].dir;
+	encoders_state[i].time_last = millis;
+	encoders_state[i].cnt      += stt;
+
+	if (encoders_state[i].cnt > AXIS_MAX_VALUE) encoders_state[i].cnt = AXIS_MAX_VALUE;
+	if (encoders_state[i].cnt < AXIS_MIN_VALUE) encoders_state[i].cnt = AXIS_MIN_VALUE;
+}
+
 void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * p_dev_config)
 {	
 	uint8_t encoders_present = 0;
 	
-	// check if fast encoder present
 	if (encoders_state[0].pin_a >=0 && encoders_state[0].pin_b >=0) 
 	{
 		encoders_state[0].cnt = (int16_t)(TIM1->CNT);
 	}
 	
-	// search if there is at least one polling encoder present
 	for (int i=1; i<MAX_ENCODERS_NUM; i++)
 	{
 		if (encoders_state[i].pin_a >=0 && encoders_state[i].pin_b >=0) 
@@ -133,122 +232,47 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 	{
 		if (encoders_state[i].pin_a >=0 && encoders_state[i].pin_b >=0)
 		{
-			int8_t stt = 0;
-			encoders_state[i].state <<= 2;
-			
-			if (raw_buttons_data[p_dev_config->buttons[encoders_state[i].pin_a].physical_num]) encoders_state[i].state |= 0x01;
-			if (raw_buttons_data[p_dev_config->buttons[encoders_state[i].pin_b].physical_num]) encoders_state[i].state |= 0x02;
-			
-			uint8_t cur  = encoders_state[i].state & 0x03;
-			uint8_t prev = (encoders_state[i].state >> 2) & 0x03;
+			/* Leitura dos pinos A e B
+			 * Button GND: repouso=HIGH=1, acionado=LOW=0 */
+			uint8_t pin_a = raw_buttons_data[p_dev_config->buttons[encoders_state[i].pin_a].physical_num] ? 1 : 0;
+			uint8_t pin_b = raw_buttons_data[p_dev_config->buttons[encoders_state[i].pin_b].physical_num] ? 1 : 0;
+			uint8_t ab = (pin_b << 1) | pin_a;
 
-			// Inicia ciclo ao sair do repouso (11) com apenas um pino liberado
-			if (prev == 0x03 && (cur == 0x01 || cur == 0x02))
+			if (p_dev_config->encoders[i] == ENCODER_CONF_4x)
 			{
-				encoders_state[i].cycle_started = 1;
-			}
-
-			if (cur != prev)
-			{
-				switch (p_dev_config->encoders[i])
+				/* Modo 4x — enc_array_4 original com leitura de 4 bits (prev+cur).
+				 * Necessario para ALPS RKJXT1F42001: detent em AB=00 e AB=11,
+				 * gerando pulso a cada meia-rotacao. */
+				encoders_state[i].state = ((encoders_state[i].state << 2) & 0x0C) | ab;
+				uint8_t cur  = encoders_state[i].state & 0x03;
+				uint8_t prev = (encoders_state[i].state >> 2) & 0x03;
+				if (cur != prev)
 				{
-					default:
-					case ENCODER_CONF_1x:
-						stt = enc_array_1[encoders_state[i].state & 0x0F];
-					break;
-					
-					case ENCODER_CONF_2x:
-						stt = enc_array_2[encoders_state[i].state & 0x0F];
-						break;
-					
-					case ENCODER_CONF_4x:
-						stt = enc_array_4[encoders_state[i].state & 0x0F];
-						break;
-				}
-				
-				if (stt != 0 && encoders_state[i].cycle_started)
-				{
-					encoders_state[i].dir = stt > 0 ? 1 : -1;
-					if ((millis - encoders_state[i].time_last > 50) || (encoders_state[i].dir == encoders_state[i].last_dir))
+					int8_t stt = enc_array_4[encoders_state[i].state & 0x0F];
+					if (stt != 0)
 					{
-						if (stt > 0)	
-						{
-							if ((p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator > 0 && 
-									 shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator-1)))
-							{
-								button_state_buf[encoders_state[i].pin_a].current_state = 1;
-							}
-							else if (p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator == 0) 
-							{
-								uint8_t tmp_ignore = 0;
-								for (int k = 0; k < MAX_ENCODERS_NUM; k++)
-								{
-									if (p_dev_config->buttons[encoders_state[i].pin_a].physical_num == ignore_a[k])
-									{
-										tmp_ignore = 1;
-										break;
-									}
-								}
-								if (tmp_ignore == 0)
-								{
-									button_state_buf[encoders_state[i].pin_a].current_state = 1;
-								}
-							}
-						}
-						else if (stt < 0)
-						{
-							if ((p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator > 0 && 
-									 shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator-1)))
-							{
-								button_state_buf[encoders_state[i].pin_b].current_state = 1;
-							}
-							else if (p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator == 0) 
-							{
-								uint8_t tmp_ignore = 0;
-								for (int k = 0; k < MAX_ENCODERS_NUM; k++)
-								{
-									if (p_dev_config->buttons[encoders_state[i].pin_b].physical_num == ignore_b[k])
-									{
-										tmp_ignore = 1;
-										break;
-									}
-								}
-								if (tmp_ignore == 0)
-								{
-									button_state_buf[encoders_state[i].pin_b].current_state = 1;
-								}
-							}
-						}		
-						encoders_state[i].last_dir = encoders_state[i].dir;
-						encoders_state[i].time_last = millis;
-						encoders_state[i].cnt += stt;
-						
-						if (encoders_state[i].cnt > AXIS_MAX_VALUE) encoders_state[i].cnt = AXIS_MAX_VALUE;
-						if (encoders_state[i].cnt < AXIS_MIN_VALUE) encoders_state[i].cnt = AXIS_MIN_VALUE;
-						
-						// Reseta ciclo apos emitir saida valida
-						encoders_state[i].cycle_started = 0;
-					}
-					else if ((millis - encoders_state[i].time_last <= 200) && (encoders_state[i].dir != encoders_state[i].last_dir))
-					{
-						// Ignorar mudanca de direcao rapida
-						encoders_state[i].time_last = millis;
-						encoders_state[i].cycle_started = 0;
+						EmitEncoderPulse(i, stt, button_state_buf, p_dev_config, ignore_a, ignore_b, millis);
 					}
 				}
-				
-				// Reseta ciclo se voltou ao repouso (11) sem completar
-				if (cur == 0x03 && encoders_state[i].cycle_started)
-				{
-					encoders_state[i].cycle_started = 0;
-				}
 			}
-			else	
+			else
 			{
-				encoders_state[i].state >>= 2;
+				/* Modos 1x e 2x — FSM de quadratura completa.
+				 * Pulso so emitido apos 4 transicoes completas.
+				 * Bounce descartado automaticamente.
+				 * Mudanca de direcao imediata sem perder o primeiro step. */
+				uint8_t next_state = fsm_quadrature[encoders_state[i].fsm_state & 0x0F][ab];
+				encoders_state[i].fsm_state = next_state & 0x0F;
+				uint8_t direction = next_state & 0x30;
+				if (direction == FSM_DIR_CW || direction == FSM_DIR_CCW)
+				{
+					int8_t stt = (direction == FSM_DIR_CW) ? 1 : -1;
+					EmitEncoderPulse(i, stt, button_state_buf, p_dev_config, ignore_a, ignore_b, millis);
+				}
 			}
 		}
-		// unpress encoder button
+
+		/* Unpress encoder button apos press_time */
 		if (encoders_state[i].pin_a >=0 && encoders_state[i].pin_b >=0)
 		{		
 			uint16_t a_press_time;
@@ -256,34 +280,34 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 
 			switch (p_dev_config->buttons[encoders_state[i].pin_a].press_timer)
 			{	
-					case BUTTON_TIMER_1:
-						a_press_time = p_dev_config->button_timer1_ms;
-						break;
-					case BUTTON_TIMER_2:
-						a_press_time = p_dev_config->button_timer2_ms;
-						break;
-					case BUTTON_TIMER_3:
-						a_press_time = p_dev_config->button_timer3_ms;
-						break;
-					default:
-						a_press_time = p_dev_config->encoder_press_time_ms;
-						break;
+				case BUTTON_TIMER_1:
+					a_press_time = p_dev_config->button_timer1_ms;
+					break;
+				case BUTTON_TIMER_2:
+					a_press_time = p_dev_config->button_timer2_ms;
+					break;
+				case BUTTON_TIMER_3:
+					a_press_time = p_dev_config->button_timer3_ms;
+					break;
+				default:
+					a_press_time = p_dev_config->encoder_press_time_ms;
+					break;
 			};
 			
 			switch (p_dev_config->buttons[encoders_state[i].pin_b].press_timer)
 			{	
-					case BUTTON_TIMER_1:
-						b_press_time = p_dev_config->button_timer1_ms;
-						break;
-					case BUTTON_TIMER_2:
-						b_press_time = p_dev_config->button_timer2_ms;
-						break;
-					case BUTTON_TIMER_3:
-						b_press_time = p_dev_config->button_timer3_ms;
-						break;
-					default:
-						b_press_time = p_dev_config->encoder_press_time_ms;
-						break;
+				case BUTTON_TIMER_1:
+					b_press_time = p_dev_config->button_timer1_ms;
+					break;
+				case BUTTON_TIMER_2:
+					b_press_time = p_dev_config->button_timer2_ms;
+					break;
+				case BUTTON_TIMER_3:
+					b_press_time = p_dev_config->button_timer3_ms;
+					break;
+				default:
+					b_press_time = p_dev_config->encoder_press_time_ms;
+					break;
 			};
 			
 			if (millis - encoders_state[i].time_last > a_press_time)
@@ -309,6 +333,7 @@ void EncodersInit(dev_config_t * p_dev_config)
 		encoders_state[i].pin_a = -1;
 		encoders_state[i].pin_b = -1;
 		encoders_state[i].state = 0;
+		encoders_state[i].fsm_state = FSM_R_START;
 		encoders_state[i].time_last = 0;
 		encoders_state[i].cycle_started = 0;
 	}
@@ -334,6 +359,7 @@ void EncodersInit(dev_config_t * p_dev_config)
 					encoders_state[pos].dir = 1;
 					encoders_state[pos].last_dir = 1;
 					encoders_state[pos].cycle_started = 0;
+					encoders_state[pos].fsm_state = FSM_R_START;
 					
 					prev_a = i;
 					prev_b = j;

--- a/application/Src/encoders.c
+++ b/application/Src/encoders.c
@@ -60,7 +60,6 @@ static void EncoderFastInit(dev_config_t * p_dev_config)
 	
 	// Encoder timer
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM1, ENABLE);		
-	//TIM_TimeBaseStructInit(&TIM_TimeBaseInitStructure);	
 	TIM_TimeBaseInitStructure.TIM_Prescaler = 0;
 	TIM_TimeBaseInitStructure.TIM_Period = 65535;
 	TIM_TimeBaseInitStructure.TIM_ClockDivision = 0;
@@ -85,15 +84,13 @@ static void EncoderFastInit(dev_config_t * p_dev_config)
 
 void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * p_dev_config)
 {	
-	
 	uint8_t encoders_present = 0;
 	
 	// check if fast encoder present
 	if (encoders_state[0].pin_a >=0 && encoders_state[0].pin_b >=0) 
-		{
-			encoders_state[0].cnt = (int16_t)(TIM1->CNT);
-		}
-	
+	{
+		encoders_state[0].cnt = (int16_t)(TIM1->CNT);
+	}
 	
 	// search if there is at least one polling encoder present
 	for (int i=1; i<MAX_ENCODERS_NUM; i++)
@@ -104,18 +101,15 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 			break;
 		}
 	}
-	if (!encoders_present) return;		// dont waste time if no encoders connected
-	
+	if (!encoders_present) return;
 	
 	int8_t ignore_a[MAX_ENCODERS_NUM]={};
 	int8_t ignore_b[MAX_ENCODERS_NUM]={};
-	// because physical_num = -1 - no button
 	for (int k=0; k<MAX_ENCODERS_NUM; k++)
 	{
 		ignore_a[k] = -1;
 		ignore_b[k] = -1;
 	}	
-	// search encoder phys number with shift mod enabled
 	uint8_t tmp_a = 0;
 	uint8_t tmp_b = 0;
 	
@@ -123,13 +117,11 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 	
 	for (int k = 0; k < MAX_ENCODERS_NUM; k++)
 	{
-		// Pin A
 		if (p_dev_config->buttons[encoders_state[k].pin_a].shift_modificator > 0 && 
 		 shifts_state & 1<<(p_dev_config->buttons[encoders_state[k].pin_a].shift_modificator-1))
 		{
 			ignore_a[tmp_a++] = p_dev_config->buttons[encoders_state[k].pin_a].physical_num;
 		}
-		// Pin B
 		if (p_dev_config->buttons[encoders_state[k].pin_b].shift_modificator > 0 && 
 		 shifts_state & 1<<(p_dev_config->buttons[encoders_state[k].pin_b].shift_modificator-1))
 		{
@@ -141,13 +133,22 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 	{
 		if (encoders_state[i].pin_a >=0 && encoders_state[i].pin_b >=0)
 		{
-			int8_t stt;
-			encoders_state[i].state <<= 2;			// shift prev state to clear space for new data
+			int8_t stt = 0;
+			encoders_state[i].state <<= 2;
 			
-			if (raw_buttons_data[p_dev_config->buttons[encoders_state[i].pin_a].physical_num])	encoders_state[i].state |= 0x01;		// Pin A high
-			if (raw_buttons_data[p_dev_config->buttons[encoders_state[i].pin_b].physical_num])	encoders_state[i].state |= 0x02;		// Pin B high
+			if (raw_buttons_data[p_dev_config->buttons[encoders_state[i].pin_a].physical_num]) encoders_state[i].state |= 0x01;
+			if (raw_buttons_data[p_dev_config->buttons[encoders_state[i].pin_b].physical_num]) encoders_state[i].state |= 0x02;
 			
-			if ((encoders_state[i].state & 0x03) != ((encoders_state[i].state >> 2) & 0x03))							// Current state != Prev state
+			uint8_t cur  = encoders_state[i].state & 0x03;
+			uint8_t prev = (encoders_state[i].state >> 2) & 0x03;
+
+			// Inicia ciclo ao sair do repouso (11) com apenas um pino liberado
+			if (prev == 0x03 && (cur == 0x01 || cur == 0x02))
+			{
+				encoders_state[i].cycle_started = 1;
+			}
+
+			if (cur != prev)
 			{
 				switch (p_dev_config->encoders[i])
 				{
@@ -165,137 +166,81 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 						break;
 				}
 				
-				if (stt != 0)		// changed
+				if (stt != 0 && encoders_state[i].cycle_started)
 				{
-						encoders_state[i].dir = stt > 0 ? 1 : -1;
-						if ((millis - encoders_state[i].time_last > 50) || (encoders_state[i].dir == encoders_state[i].last_dir))	// if direction didnt change too fast
+					encoders_state[i].dir = stt > 0 ? 1 : -1;
+					if ((millis - encoders_state[i].time_last > 50) || (encoders_state[i].dir == encoders_state[i].last_dir))
+					{
+						if (stt > 0)	
 						{
-							if (stt > 0)	
+							if ((p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator > 0 && 
+									 shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator-1)))
 							{
-								// activate encoder with enable shift mod
-								if ((p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator > 0 && 
-										 shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator-1)))
-								{
-									button_state_buf[encoders_state[i].pin_a].current_state = 1;			// CW
-								}
-								// if shift mod disabled
-								else if (p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator == 0) 
-								{
-									uint8_t tmp_ignore = 0;
-									// check button in ignore list
-									for (int k = 0; k < MAX_ENCODERS_NUM; k++)	// if ignore_a[k] == 0 break; ?
-									{
-										if (p_dev_config->buttons[encoders_state[i].pin_a].physical_num == ignore_a[k])
-										{
-											tmp_ignore = 1;
-											break;
-										}
-									}
-									// activate if not found in ignore list
-									if (tmp_ignore == 0)
-									{
-										button_state_buf[encoders_state[i].pin_a].current_state = 1;			// CW
-									}
-								}
+								button_state_buf[encoders_state[i].pin_a].current_state = 1;
 							}
-							else if (stt < 0)
+							else if (p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator == 0) 
 							{
-								// activate encoder with enable shift mod
-								if ((p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator > 0 && 
-										 shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator-1)))
+								uint8_t tmp_ignore = 0;
+								for (int k = 0; k < MAX_ENCODERS_NUM; k++)
 								{
-									button_state_buf[encoders_state[i].pin_b].current_state = 1;			// CCW
-								}
-								// if shift mod disabled
-								else if (p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator == 0) 
-								{
-									uint8_t tmp_ignore = 0;
-									// check button in ignore list
-									for (int k = 0; k < MAX_ENCODERS_NUM; k++)	// if ignore_b[k] == 0 break; ?
+									if (p_dev_config->buttons[encoders_state[i].pin_a].physical_num == ignore_a[k])
 									{
-										if (p_dev_config->buttons[encoders_state[i].pin_b].physical_num == ignore_b[k])
-										{
-											tmp_ignore = 1;
-											break;
-										}
-									}
-									// activate if not found in ignore list
-									if (tmp_ignore == 0)
-									{
-										button_state_buf[encoders_state[i].pin_b].current_state = 1;			// CCW
+										tmp_ignore = 1;
+										break;
 									}
 								}
-							}		
-							encoders_state[i].last_dir = encoders_state[i].dir;
-							encoders_state[i].time_last = millis;
-							encoders_state[i].cnt += stt;
-							
-							if (encoders_state[i].cnt > AXIS_MAX_VALUE) encoders_state[i].cnt = AXIS_MAX_VALUE;
-							if (encoders_state[i].cnt < AXIS_MIN_VALUE) encoders_state[i].cnt = AXIS_MIN_VALUE;
-							
-						}
-						else if ((millis - encoders_state[i].time_last <= 200) && (encoders_state[i].dir != encoders_state[i].last_dir))
-						{
-							encoders_state[i].time_last = millis;
-							encoders_state[i].cnt += encoders_state[i].last_dir;
-							//encoders_state[i].state <<= 2;
-							if (encoders_state[i].last_dir > 0)	
-							{
-								// activate encoder with enable shift mod
-								if ((p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator > 0 && 
-										 shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator-1)))
+								if (tmp_ignore == 0)
 								{
-									button_state_buf[encoders_state[i].pin_a].current_state = 1;			// CW
-								}
-								// if shift mod disabled
-								else if (p_dev_config->buttons[encoders_state[i].pin_a].shift_modificator == 0) 
-								{
-									uint8_t tmp_ignore = 0;
-									// check button in ignore list
-									for (int a = 0; a < MAX_ENCODERS_NUM; a++)
-									{
-										if (p_dev_config->buttons[encoders_state[i].pin_a].physical_num == ignore_a[a])
-										{
-											tmp_ignore = 1;
-											break;
-										}
-									}
-									// activate if not found in ignore list
-									if (tmp_ignore == 0)
-									{
-										button_state_buf[encoders_state[i].pin_a].current_state = 1;			// CW
-									}
-								}
-							}
-							else
-							{
-								// activate encoder with enable shift mod
-								if ((p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator > 0 && 
-										 shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator-1)))
-								{
-									button_state_buf[encoders_state[i].pin_b].current_state = 1;			// CCW
-								}
-								// if shift mod disabled
-								else if (p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator == 0) 
-								{
-									uint8_t tmp_ignore = 0;
-									// check button in ignore list
-									for (int k = 0; k < MAX_ENCODERS_NUM; k++)	// if ignore_b[k] == 0 break; ?
-									{
-										if (p_dev_config->buttons[encoders_state[i].pin_b].physical_num == ignore_b[k])
-										{
-											tmp_ignore = 1;
-											break;
-										}
-									}
-									// activate if not found in ignore list
-									if (tmp_ignore == 0)
-									{
-										button_state_buf[encoders_state[i].pin_b].current_state = 1;			// CCW
-									}
+									button_state_buf[encoders_state[i].pin_a].current_state = 1;
 								}
 							}
 						}
+						else if (stt < 0)
+						{
+							if ((p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator > 0 && 
+									 shifts_state & 1<<(p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator-1)))
+							{
+								button_state_buf[encoders_state[i].pin_b].current_state = 1;
+							}
+							else if (p_dev_config->buttons[encoders_state[i].pin_b].shift_modificator == 0) 
+							{
+								uint8_t tmp_ignore = 0;
+								for (int k = 0; k < MAX_ENCODERS_NUM; k++)
+								{
+									if (p_dev_config->buttons[encoders_state[i].pin_b].physical_num == ignore_b[k])
+									{
+										tmp_ignore = 1;
+										break;
+									}
+								}
+								if (tmp_ignore == 0)
+								{
+									button_state_buf[encoders_state[i].pin_b].current_state = 1;
+								}
+							}
+						}		
+						encoders_state[i].last_dir = encoders_state[i].dir;
+						encoders_state[i].time_last = millis;
+						encoders_state[i].cnt += stt;
+						
+						if (encoders_state[i].cnt > AXIS_MAX_VALUE) encoders_state[i].cnt = AXIS_MAX_VALUE;
+						if (encoders_state[i].cnt < AXIS_MIN_VALUE) encoders_state[i].cnt = AXIS_MIN_VALUE;
+						
+						// Reseta ciclo apos emitir saida valida
+						encoders_state[i].cycle_started = 0;
+					}
+					else if ((millis - encoders_state[i].time_last <= 200) && (encoders_state[i].dir != encoders_state[i].last_dir))
+					{
+						// Ignorar mudanca de direcao rapida
+						encoders_state[i].time_last = millis;
+						encoders_state[i].cycle_started = 0;
+					}
+				}
+				
+				// Reseta ciclo se voltou ao repouso (11) sem completar
+				if (cur == 0x03 && encoders_state[i].cycle_started)
+				{
+					encoders_state[i].cycle_started = 0;
 				}
 			}
 			else	
@@ -309,7 +254,6 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 			uint16_t a_press_time;
 			uint16_t b_press_time;
 
-			// check if press time is redefined
 			switch (p_dev_config->buttons[encoders_state[i].pin_a].press_timer)
 			{	
 					case BUTTON_TIMER_1:
@@ -341,8 +285,7 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 						b_press_time = p_dev_config->encoder_press_time_ms;
 						break;
 			};
-					
-		
+			
 			if (millis - encoders_state[i].time_last > a_press_time)
 			{	
 				button_state_buf[encoders_state[i].pin_a].current_state = 0;
@@ -357,7 +300,7 @@ void EncoderProcess (logical_buttons_state_t * button_state_buf, dev_config_t * 
 
 void EncodersInit(dev_config_t * p_dev_config)
 {
-	uint8_t pos = 1;		// polling encoders start from pos = 1
+	uint8_t pos = 1;
 	int8_t prev_a = -1;
 	int8_t prev_b = -1;
 	
@@ -367,22 +310,17 @@ void EncodersInit(dev_config_t * p_dev_config)
 		encoders_state[i].pin_b = -1;
 		encoders_state[i].state = 0;
 		encoders_state[i].time_last = 0;
+		encoders_state[i].cycle_started = 0;
 	}
 	
-	// check if fast encoder connected
 	if (p_dev_config->pins[8] == FAST_ENCODER &&
 			p_dev_config->pins[9] == FAST_ENCODER)
 	{
-		// fast ancoder always at pos=0
 		encoders_state[0].pin_a = 8;
 		encoders_state[0].pin_b = 9;
-//		encoders_state[0].dir = 1;
-//		encoders_state[0].last_dir = 1;
-		
 		EncoderFastInit(p_dev_config);
 	}
 	
-	// check if slow encoders connected to buttons inputs
 	for (int i=0; i<MAX_BUTTONS_NUM; i++)
 	{
 		if ((p_dev_config->buttons[i].type) == ENCODER_INPUT_A &&  i > prev_a)
@@ -395,6 +333,7 @@ void EncodersInit(dev_config_t * p_dev_config)
 					encoders_state[pos].pin_b = j;
 					encoders_state[pos].dir = 1;
 					encoders_state[pos].last_dir = 1;
+					encoders_state[pos].cycle_started = 0;
 					
 					prev_a = i;
 					prev_b = j;


### PR DESCRIPTION
## Problem

The original encoder implementation had multiple issues:

**1. Ghost HID output on partial rotation**
When using rotary encoders configured as ENCODER_CONF_1x, a ghost HID output 
was generated when the user partially rotated the encoder and released it before 
completing the full quadrature cycle.

**2. Lost pulses on EC11 encoders**
The original code blocked pulses based on time (50ms) and direction history, 
causing EC11 encoders to lose steps during normal use.

**3. First step lost when changing direction quickly**
When rotating in one direction and immediately reversing, the first step in the 
new direction was lost.

## Root Cause

The original lookup table logic used time-based filtering and direction history 
(`last_dir`) to debounce encoders. This approach works for some encoders but 
fails on others, particularly EC11, which has different timing characteristics.

## Solution

Replaced the original lookup table with a full quadrature FSM (Finite State 
Machine) for ENCODER_CONF_1x and ENCODER_CONF_2x modes.

- Bounce rejection is handled structurally by the FSM — only complete valid 
  quadrature cycles generate HID output
- Direction changes are detected immediately without losing the first step
- No time-based filtering that could block valid pulses
- ENCODER_CONF_4x retains the original enc_array_4 logic, required for encoders 
  like the ALPS RKJXT1F42001 that have detents at AB=00

## Modified files

- `application/Src/encoders.c` — FSM implementation + refactored EmitEncoderPulse
- `application/Inc/common_types.h` — added `fsm_state` field to `encoder_state_t`

## Tested on

- EC16 configured as ENCODER_CONF_1x ✓
- EC11 configured as ENCODER_CONF_1x ✓
- ALPS RKJXT1F42001 configured as ENCODER_CONF_4x ✓

## Pre-compiled firmware

Pre-compiled `.bin` and `.hex` files are available in the releases section for 
direct flashing without the need to compile.